### PR TITLE
Fix Dockerfile builds to the wrong folder.

### DIFF
--- a/docker/dc-api/Dockerfile
+++ b/docker/dc-api/Dockerfile
@@ -4,11 +4,9 @@ MAINTAINER Data to Insight Center <d2i@indiana.edu>
 
 USER root
 
-WORKDIR /opt
+WORKDIR $CATALINA_HOME
 
-WORKDIR /opt/tomcat/webapps/
-ADD sloan-ws*.war /opt/tomcat/webapps/sloan-ws.war
-RUN unzip -qq sloan-ws.war -d sloan-ws
+ADD sloan-ws*.war
 
 # Create directory to keep DC API configuration files
 RUN mkdir -p /etc/htrc/dcapi


### PR DESCRIPTION
According to the Tomcat documentation the webapps folder needs to go
into .  is defined in the docker image that
is being used but is not referenced in the Dockerfile. Although the
Dockerfile builds without failure all request to the app fail with 404
because the sloan-ws.jar file is not added to the correct folder.

This change updates the Dockerfile to use /webapps as the
build target for sloan-ws.jar.

It also removes the unnecessary unpacking step of the jar file since
this gets automatically done by tomcat the first time the user attempts
to view the app.